### PR TITLE
design: header 배경색 자식에서 변경 가능

### DIFF
--- a/src/context/HeaderContext.js
+++ b/src/context/HeaderContext.js
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState } from "react";
+
+const HeaderColorContext = createContext();
+
+export function HeaderColorProvider({ children }) {
+  const [headerBackColor, setHeaderBackColor] = useState("#ffffff");
+  const [headerTextColor, setHeaderTextColor] = useState("#000000");
+
+  return (
+    <HeaderColorContext.Provider
+      value={{
+        headerBackColor,
+        setHeaderBackColor,
+        headerTextColor,
+        setHeaderTextColor,
+      }}
+    >
+      {children}
+    </HeaderColorContext.Provider>
+  );
+}
+
+// 커스텀 훅
+export function useHeaderColor() {
+  return useContext(HeaderColorContext);
+}

--- a/src/layout/Header.js
+++ b/src/layout/Header.js
@@ -5,15 +5,22 @@ import { ReactComponent as LOGO } from "../assets/images/header/logo.svg";
 import { ReactComponent as SEARCH } from "../assets/images/header/search.svg";
 import { ReactComponent as CART } from "../assets/images/header/cart.svg";
 import { ReactComponent as MENU } from "../assets/images/header/menu.svg";
+import { useHeaderColor } from "../context/HeaderContext";
 
 function Header() {
+  const { headerBackColor, headerTextColor } = useHeaderColor();
+
   return (
     <>
-      {/* <ParentContainer> */}
-      {/* <div className="container mx-auto h-11 bg-black"> */}
-      <div className="w-full h-11 bg-content px-5">
+      <div
+        className="w-full h-11 bg-content px-5"
+        style={{ backgroundColor: headerBackColor }}
+      >
         <div className="max-w-5xl mx-auto h-full">
-          <ul className="flex h-full md:justify-between text-white">
+          <ul
+            className="flex h-full md:justify-between text-white"
+            style={{ color: headerTextColor }}
+          >
             <li className="flex-grow md:flex-grow-0">
               <a href="#" className="inline-block px-2">
                 <LOGO />
@@ -121,8 +128,6 @@ function Header() {
           </ul>
         </div>
       </div>
-
-      {/* </ParentContainer> */}
     </>
   );
 }

--- a/src/layout/MainLayout.js
+++ b/src/layout/MainLayout.js
@@ -1,13 +1,14 @@
 import React from "react";
 import Header from "./Header";
 import { Outlet } from "react-router-dom";
+import { HeaderColorProvider } from "../context/HeaderContext";
 
 function MainLayout() {
   return (
-    <>
+    <HeaderColorProvider>
       <Header />
       <Outlet />
-    </>
+    </HeaderColorProvider>
   );
 }
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,7 +1,15 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useHeaderColor } from "../context/HeaderContext";
 
 function HomePage() {
-  return <div>HomePage</div>;
+  const { setHeaderBackColor, setHeaderTextColor } = useHeaderColor();
+
+  useEffect(() => {
+    setHeaderBackColor("rgba(22, 22, 23, .8)");
+    setHeaderTextColor("#fff");
+  }, []);
+
+  return <div>HOMEPAGE</div>;
 }
 
 export default HomePage;


### PR DESCRIPTION
## 해당 사항
- design: header ui

## Issue number
- Issue : 아직 메뉴 hover창은 만들지 않았습니다. header-ui가 있으면 레이아웃 잡기 수월할 거라 생각되어 header ui만 먼저 업로드합니다.

## 설명
각 Page에 따라 header의 background color를 지정할 수 있습니다.
아래는 HomePage 컴포넌트에서 header의 색상을 변경하는 예시입니다.
다음과 같이 색상만 변경하여 함수에 색상을 넣어주시면 됩니다.

```
import React, { useEffect } from "react";
import { useHeaderColor } from "../context/HeaderContext";

function HomePage() {
  const { setHeaderBackColor, setHeaderTextColor } = useHeaderColor();

  useEffect(() => {
    setHeaderBackColor("rgba(22, 22, 23, .8)");
    setHeaderTextColor("#fff");
  }, []);

  return <div>HOMEPAGE</div>;
}

export default HomePage;

```